### PR TITLE
Fixes issue #618 of jsPlumb. When dragging the element by default is …

### DIFF
--- a/src/katavorio.js
+++ b/src/katavorio.js
@@ -250,7 +250,8 @@
                 return pos;
             }
             else {
-                return _snap(pos, this.params.grid[0], this.params.grid[1]);
+                this.params.snapTolerance = this.params.snapTolerance || [this.params.grid[0] / 2, this.params.grid[1] / 2];
+                return _snap(pos, this.params.grid[0], this.params.grid[1], this.params.snapTolerance[0], this.params.snapTolerance[1]);
             }
         };
 


### PR DESCRIPTION
When dragging the element by default is restricted to the grid. A snapTolerance can be set in the form of an array to customize the tolerance. This snapTolerance defaults to the half of the grid size (instead of 5).